### PR TITLE
Add Custom REST api LLMs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,80 @@ curl -fsSL https://ollama.com/install.sh | sh
 #### After you have installed Ollama
 Running lexido locally is as easy as adding the `-l` flag when you want to run locally, or using `--setLocal` to run locally by default! You can also select the model you want to run with `-m` and again set it to be the default with `--setModel`. Be sure you have the model installed before attempting to run it with lexido however! 
 
+## Running remotely
+
+This guide provides instructions on how to create and customize the JSON configuration files necessary for API integration within lexido. Each configuration allows the application to interact with a different external API by specifying endpoints, headers, data templates, and specific fields to extract from API responses.
+
+### Default Configuration
+
+The default configuration template is provided as a baseline. This template includes placeholders that should be customized based on the specific API you want to integrate with.
+
+#### Example Default Configuration
+
+```json
+{
+  "api_config": {
+    "url": "https://api.example.com/endpoint/v1/chat/completions",
+    "headers": {
+      "Content-Type": "application/json",
+      "Accept": "application/json"
+    },
+    "data_template": {
+      "model": "example-model",
+      "messages": "<PROMPT>"
+    },
+    "field_to_extract": "response"
+  }
+}
+```
+
+#### Fields Explanation
+
+- **url**: The endpoint URL of the API you are calling.
+- **headers**: HTTP headers to include with your request. Common headers include `Content-Type` and `Accept`.
+- **data_template**: The data body of your request. `<PROMPT>` will be replaced dynamically by the application.
+- **field_to_extract**: The field within the API response from which data should be extracted.
+
+### Configuration for oLlama
+
+Below is an example configuration specifically set up for interacting with the oLlama API, which is assumed to run locally.
+
+#### Example oLlama Configuration
+
+```json
+{
+  "api_config": {
+    "url": "http://localhost:11434/api/generate",
+    "headers": {
+      "Content-Type": "application/json",
+      "Accept": "application/json"
+    },
+    "data_template": {
+      "model": "llama2",
+      "prompt": "<PROMPT>"
+    },
+    "field_to_extract": "response"
+  }
+}
+```
+
+#### Customization Tips
+
+- **Model**: Depending on the capabilities of the API, you might need to change the `model` value to match the model provided by the API service.
+- **Prompt**: The `<PROMPT>` placeholder in `data_template` will be replaced with the actual query or command you wish to send to the API.
+
+### Creating Your Configuration
+
+To create your own configuration:
+
+1. Copy the default configuration template. The location for the config is `~/.lexido/remoteConfig.json`
+2. Replace the `url`, `headers`, `data_template`, and `field_to_extract` fields as needed for your specific API.
+3. Ensure all placeholders like `<PROMPT>` are appropriately positioned where dynamic content is expected to be inserted by the application.
+
+### Conclusion
+
+This configuration system is designed to be flexible and extendable, allowing for easy integration with various APIs by simply modifying the JSON configuration files. For advanced configurations, you may need to adjust additional parameters.
+
 ## Usage
 - To get command suggestions:
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/charmbracelet/bubbles v0.18.0
 	github.com/charmbracelet/bubbletea v0.25.0
 	github.com/google/generative-ai-go v0.10.0
-	google.golang.org/api v0.172.0
+	google.golang.org/api v0.173.0
 )
 
 require (
@@ -51,7 +51,7 @@ require (
 	golang.org/x/time v0.5.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240311132316-a219d84964c2 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240325203815-454cdb8f5daa // indirect
 	google.golang.org/grpc v1.62.1 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,8 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-google.golang.org/api v0.172.0 h1:/1OcMZGPmW1rX2LCu2CmGUD1KXK1+pfzxotxyRUCCdk=
-google.golang.org/api v0.172.0/go.mod h1:+fJZq6QXWfa9pXhnIzsjx4yI22d4aI9ZpLb58gvXjis=
+google.golang.org/api v0.173.0 h1:fz6B7GWYWLS/HfruiTsRYVKQQApJ6vasTYWAK6+Qo8g=
+google.golang.org/api v0.173.0/go.mod h1:ins7pTzjeBPQ3SdC/plzki6d/dQWwAWy8qVZ4Vgkzl8=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.8 h1:IhEN5q69dyKagZPYMSdIjS2HqprW324FRQZJcGqPAsM=
@@ -192,8 +192,8 @@ google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto/googleapis/api v0.0.0-20240311132316-a219d84964c2 h1:rIo7ocm2roD9DcFIX67Ym8icoGCKSARAiPljFhh5suQ=
 google.golang.org/genproto/googleapis/api v0.0.0-20240311132316-a219d84964c2/go.mod h1:O1cOfN1Cy6QEYr7VxtjOyP5AdAuR0aJ/MYZaaof623Y=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 h1:NnYq6UN9ReLM9/Y01KWNOWyI5xQ9kbIms5GGJVwS/Yc=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237/go.mod h1:WtryC6hu0hhx87FDGxWCDptyssuo68sk10vYjF+T9fY=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240325203815-454cdb8f5daa h1:RBgMaUMP+6soRkik4VoN8ojR2nex2TqZwjSSogic+eo=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240325203815-454cdb8f5daa/go.mod h1:WtryC6hu0hhx87FDGxWCDptyssuo68sk10vYjF+T9fY=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=

--- a/main.go
+++ b/main.go
@@ -365,7 +365,7 @@ func main() {
 		}
 
 	} else {
-		responseContent, err = remote.Generate(str_prompt)
+		outputChan, err := remote.GenerateContentStream(str_prompt)
 		if err != nil {
 			if strings.Contains(err.Error(), "file not found") {
 				log.Println(err.Error())
@@ -374,7 +374,11 @@ func main() {
 			log.Printf("Error generating content remotely: %v\n", err)
 			os.Exit(1)
 		}
-		p.Send(tea.AppendResponseMsg(responseContent))
+
+		for line := range outputChan {
+			responseContent += line
+			p.Send(tea.AppendResponseMsg(line))
+		}
 
 	}
 

--- a/pkg/llms/remote/remote.go
+++ b/pkg/llms/remote/remote.go
@@ -1,0 +1,119 @@
+package remote
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+
+	lexio "github.com/micr0-dev/lexido/pkg/io"
+)
+
+const defaultConfig = `{
+	"api_config": {
+	  "url": "https://api.example.com/v1/chat/completions", // Replace with your API endpoint
+	  "headers": {
+		"Content-Type": "application/json",
+		"Authorization": "Bearer 123124534545634", // Replace with your API key
+		"Accept": "application/json"
+	  },
+	  "data_template": {
+		"model": "example-model",
+		"messages": "<PROMPT>" // This is where the prompt will be inserted
+	  }
+	}
+  }`
+
+// Config represents the structure of the JSON configuration file
+type Config struct {
+	ApiConfig struct {
+		URL          string            `json:"url"`
+		Headers      map[string]string `json:"headers"`
+		DataTemplate interface{}       `json:"data_template"`
+	} `json:"api_config"`
+}
+
+// replacePrompt recursively searches for the <PROMPT> placeholder and replaces it
+func replacePrompt(data interface{}, prompt string) interface{} {
+	switch v := data.(type) {
+	case map[string]interface{}:
+		for key, value := range v {
+			v[key] = replacePrompt(value, prompt)
+		}
+	case []interface{}:
+		for i, item := range v {
+			v[i] = replacePrompt(item, prompt)
+		}
+	case string:
+		if v == "<PROMPT>" {
+			return prompt
+		}
+	}
+	return data
+}
+
+// LoadConfig loads the configuration from the file and returns it
+func LoadConfig() (Config, error) {
+	filepath, err := lexio.GetFilePath("remoteConfig.json")
+	if err != nil {
+		return Config{}, err
+	}
+
+	// Load the configuration from file
+	configFile, err := os.ReadFile(filepath)
+	if err != nil {
+		// Create a default configuration file if it doesn't exist
+		if err := os.WriteFile(filepath, []byte(defaultConfig), 0644); err != nil {
+			return Config{}, err
+		}
+		return Config{}, err
+	}
+
+	var config Config
+	if err := json.Unmarshal(configFile, &config); err != nil {
+		return Config{}, err
+	}
+
+	return config, nil
+}
+
+// Generate sends a POST request to the API endpoint with the prompt and returns the response
+func Generate(prompt string) (string, error) {
+	config, err := LoadConfig()
+	if err != nil {
+		return "", err
+	}
+
+	// Replace <PROMPT> in the DataTemplate
+	config.ApiConfig.DataTemplate = replacePrompt(config.ApiConfig.DataTemplate, prompt)
+
+	// Marshal the data template back into JSON for the API request
+	jsonData, err := json.Marshal(config.ApiConfig.DataTemplate)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Create and send the API request
+	req, err := http.NewRequest("POST", config.ApiConfig.URL, strings.NewReader(string(jsonData)))
+	if err != nil {
+		log.Fatal(err)
+	}
+	for key, value := range config.ApiConfig.Headers {
+		req.Header.Add(key, value)
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return string(responseBody), nil
+}

--- a/pkg/llms/remote/remote.go
+++ b/pkg/llms/remote/remote.go
@@ -24,7 +24,8 @@ const defaultConfig = `{
 	  "data_template": {
 		"model": "example-model",
 		"messages": "<PROMPT>"
-	  }
+	  },
+	  "field_to_extract": "response" 
 	}
   }`
 


### PR DESCRIPTION
Allows for completely custom LLM support via REST API

Example config:
```json
{
	"api_config": {
	  "url": "https://api.example.com/v1/chat/completions", // Replace with your API endpoint
	  "headers": {
		"Content-Type": "application/json",
		"Authorization": "Bearer 123124534545634", // Replace with your API key
		"Accept": "application/json"
	  },
	  "data_template": {
		"model": "example-model",
		"messages": "<PROMPT>" // This is where the prompt will be inserted
	  }
	}
  }
  ```

Can easily add support for ChatGPT, Claude, etc.